### PR TITLE
support cluster domain suffix and fix TAOS_FIRST_EP error

### DIFF
--- a/helm/tdengine/templates/statefulset.yaml
+++ b/helm/tdengine/templates/statefulset.yaml
@@ -71,10 +71,10 @@ spec:
             value: "6030"
           # Must set if you want a cluster.
           - name: TAOS_FIRST_EP
-            value: "$(STS_NAME)-0"
+            value: '$(STS_NAME)-0.$(SERVICE_NAME).$(STS_NAMESPACE).svc.{{ .Values.clusterDomainSuffix | default "cluster.local" }}:$(TAOS_SERVER_PORT)'
           # TAOS_FQND should always be setted in k8s env.
           - name: TAOS_FQDN
-            value: "$(POD_NAME)"
+            value: '$(POD_NAME).$(SERVICE_NAME).$(STS_NAMESPACE).svc.{{ .Values.clusterDomainSuffix | default "cluster.local" }}'
 
           {{ if .Values.arbitrator }}
           - name: TAOS_ARBITRATOR

--- a/helm/tdengine/values.yaml
+++ b/helm/tdengine/values.yaml
@@ -47,6 +47,7 @@ nodeSelectors:
   taosd:
     # node selectors
 
+clusterDomainSuffix: ""
 # Config settings in taos.cfg file.
 #
 # The helm/k8s support will use environment variables for taos.cfg,


### PR DESCRIPTION
When I tried to deploy tdengine with helm, I adjusted the number of instances to 3 and found that the pod of XX-1, XX-2 could not be started normally. 
This is a screenshot of the log
![log](https://s3.bmp.ovh/imgs/2021/12/08b1789db048c359.png)

When I adjust `TAOS_FRIST_EP` and `TAOS_FQDN`，The cluster can start normally
```shell
root@btbt-tdengine-0:/etc/taos# taos -s 'show dnodes'

Welcome to the TDengine shell from Linux, Client Version:2.2.1.1
Copyright (c) 2020 by TAOS Data, Inc. All rights reserved.

taos> show dnodes
   id   |           end_point            | vnodes | cores  |   status   | role  |       create_time       |      offline reason      |
======================================================================================================================================
      1 | btbt-tdengine-0.btbt-tdengi... |      0 |     16 | ready      | any   | 2021-12-16 17:49:47.471 |                          |
      2 | btbt-tdengine-1.btbt-tdengi... |      1 |     16 | ready      | any   | 2021-12-16 17:50:04.810 |                          |
      3 | btbt-tdengine-2.btbt-tdengi... |      0 |     16 | ready      | any   | 2021-12-16 17:50:13.231 |                          |
      0 | btbt-tdengine-arbitrator       |      0 |      0 | ready      | arb   | 2021-12-16 17:49:48.307 | -                        |
Query OK, 4 row(s) in set (0.000833s)

root@btbt-tdengine-0:/etc/taos#
```
